### PR TITLE
Update removeComments regex

### DIFF
--- a/lib/zonefile.js
+++ b/lib/zonefile.js
@@ -197,7 +197,7 @@
     };
 
     var removeComments = function (text) {
-        var re = /(^|[^\\]);.*/g;
+        var re = /(^|[^\\])\;(?=([^"]*"[^"]*")*[^"]*$).*/g;
         return text.replace(re, function (m, g1) {
             return g1 ? g1 : ""; // if g1 is set/matched, re-insert it, else remove
         });


### PR DESCRIPTION
To exclude semicolons inside quotes. For example in DKIM TXT records
```k1._domainkey.domain.com IN TXT "k=rsa; p=DOMAINKEY"```