### PR TITLE
Proposed fix to issue #16.

### DIFF
--- a/lib/zonefile.js
+++ b/lib/zonefile.js
@@ -242,7 +242,7 @@
             } else if (/\s+NS\s+/.test(uRR)) {
                 ret.ns = ret.ns || [];
                 ret.ns.push(parseNS(rr));
-            } else if (/\s+A\s+/.test(uRR)) {
+            } else if (/\s+A\s+/.test(uRR) && !/".*A\s+/.test(uRR)) {
                 ret.a = ret.a || [];
                 ret.a.push(parseA(rr, ret.a));
             } else if (/\s+AAAA\s+/.test(uRR)) {
@@ -251,10 +251,10 @@
             } else if (/\s+CNAME\s+/.test(uRR)) {
                 ret.cname = ret.cname || [];
                 ret.cname.push(parseCNAME(rr));
-            } else if (/\s+MX\s+/.test(uRR)) {
+            } else if (/\s+MX\s+/.test(uRR) && !/".*MX\s+/.test(uRR)) {
                 ret.mx = ret.mx || [];
                 ret.mx.push(parseMX(rr));
-            } else if (/\s+PTR\s+/.test(uRR)) {
+            } else if (/\s+PTR\s+/.test(uRR) && !/".*PTR\s+/.test(uRR)) {
                 ret.ptr = ret.ptr || [];
                 ret.ptr.push(parsePTR(rr, ret.ptr, ret.$origin));
             } else if (/\s+SRV\s+/.test(uRR)) {


### PR DESCRIPTION
This is a proposed fix to issue #16 that was opened earlier.

Based on the syntax defined in [http://www.openspf.org/SPF_Record_Syntax](http://www.openspf.org/SPF_Record_Syntax), I included double checks to make sure the "record type" was not found inside a quote. A, MX, and PTR records are valid references in SPF.

**Before**
`} else if (/\s+A\s+/.test(uRR)) {`
**After**
`} else if (/\s+A\s+/.test(uRR) && !/".*A\s+/.test(uRR)) {`

This was intended to be a non-breaking as possible change.

Output After Change
```
{ '$ttl': '604800',
  soa:
   { name: '@',
     minimum: 604800,
     expire: 2419200,
     retry: 86400,
     refresh: 604800,
     serial: 2015040102,
     rname: 'dns.example.com.',
     mname: 'ns1.example.com.' },
  ns: [ { name: '@', host: 'ns1.example.com.' } ],
  spf: [ { name: '@', data: 'a mx ~all"' } ] }
```