### PR TITLE
Remove " for TXT records when parsing zonefile

### DIFF
--- a/lib/zonefile.js
+++ b/lib/zonefile.js
@@ -439,6 +439,9 @@
         };
 
         if (rrData.hasTtl) result.ttl = parseInt(rrTokens[1], 10);
+        if (result.txt.startsWith('"') && result.txt.endsWith('"')) {
+            result.txt = result.txt.slice(1, -1);
+        }
         return result;
     };
 


### PR DESCRIPTION
Sometimes TXT record are surround with " in zone file, for example DKIM entries :
```
_domainkey	IN	TXT "t=y; o=-;"
```

When I parse the zone file, the double-quotes are also load to the created object, like this :
```
txt: [ { name: '"_domainkey', txt: 't=y; o=-;"' }]
```
This behavior is a little bit annoying because when I parse a zone file, made some modifications (not on the TXT record) and generate the new zone file, I have the following result, which is not valid for some DNS parser (in that case, the parser of my registrar).
```
; TXT Records
_domainkey	IN	TXT	""t=y; o=-;""
```

It is quite simple for user to remove those double quotes after parsing the file, but I suggest to do it on the `parse` function directly.