### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ output = zonefile.parse(text);
 console.log(JSON.stringify(output));
 ```
 
-#License
+# License
 ISC License (ISC)
 
 Copyright (c) 2014, Elgs Qian Chen


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
