### PR TITLE
Add async version of parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ output = zonefile.parse(text);
 console.log(JSON.stringify(output));
 ```
 
+_dns-zonefile_ also exports an async version of parsing called `parseAsync()` which returns a Promise. 
+`parseAsync` runs on the main JS thread with added interrupts, so it does not block the node.js (or browser) event loop
+for the whole operation.  
+
+```javascript
+var zonefile = require('dns-zonefile');
+var text = fs.readFileSync('./zonefile_forward.txt', 'utf8');
+zonefile.parseAsync(text).then(output => {
+  console.log(JSON.stringify(output));
+});
+```
+
 # License
 ISC License (ISC)
 

--- a/lib/zonefile-es.js
+++ b/lib/zonefile-es.js
@@ -46,6 +46,8 @@ let defaultTemplate = `; Zone: {zone}
 
 `;
 
+let interrupt = () => new Promise(resolve => setTimeout(resolve, 0));
+
 export let generate = function (options, template) {
   template = template || defaultTemplate;
   template = process$ORIGIN(options['$origin'], template);
@@ -208,33 +210,69 @@ export let parse = function (text) {
   return parseRRs(text);
 };
 
+export let parseAsync = async function (text) {
+  text = removeComments(text);
+  await interrupt();
+  text = await flattenAsync(text);
+  await interrupt();
+  return parseRRsAsync(text);
+};
+
+// Keep this regex definition out of the function as it's expensive
+let removeCommentsRegex = /\\"|"(?:\\"|[^"])*"|((^|[^\\])\;.*)/g;
+
 let removeComments = function (text) {
   // let re = /(^|[^\\])\;(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$).*/g;
   // return text.replace(re, function (m, g1) {
   //     return g1 ? g1 : ""; // if g1 is set/matched, re-insert it, else remove
   // });
 
-  let re = /\\"|"(?:\\"|[^"])*"|((^|[^\\])\;.*)/g;
-  return text.replace(re, function (m, g1) {
+  return text.replace(removeCommentsRegex, function (m, g1) {
     return !g1 ? m : ""; // if g1 is not set/matched, re-insert it, else remove
   });
 };
 
+
+let flattenRegex = /\([\s\S]*?\)/gim;
+
+let replaceWhitespaces = function (text) {
+  return text.replace(/\s+/gm, ' ');
+}
+
 let flatten = function (text) {
   let captured = [];
-  let re = /\([\s\S]*?\)/gim;
-  let match = re.exec(text);
+  let match = flattenRegex.exec(text);
   while (match !== null) {
-    match.replacement = match[0].replace(/\s+/gm, ' ');
+    match.replacement = replaceWhitespaces(text);
     captured.push(match);
     // captured Text, index, input
-    match = re.exec(text);
+    match = flattenRegex.exec(text);
   }
   let arrText = text.split('');
   for (match of captured) {
     arrText.splice(match.index, match[0].length, match.replacement);
   }
   return arrText.join('').replace(/\(|\)/gim, ' ');
+};
+
+// this function should match flatten above, the only difference is the added interrupt.
+let flattenAsync = async function (text) {
+  let captured = [];
+  let match = flattenRegex.exec(text);
+  while (match !== null) {
+    match.replacement = replaceWhitespaces(text);
+    captured.push(match);
+    // captured Text, index, input
+    match = flattenRegex.exec(text);
+    await interrupt();
+  }
+  let arrText = text.split('');
+  for (match of captured) {
+    arrText.splice(match.index, match[0].length, match.replacement);
+  }
+  let joinedText = arrText.join('');
+  await interrupt();
+  return joinedText.replace(/\(|\)/gim, ' ');
 };
 
 let normalizeRR = function (rr, rrType) {
@@ -272,6 +310,47 @@ let normalizeRR = function (rr, rrType) {
   };
 };
 
+let parseRR = function (rr, ret) {
+  let rrArray = splitArgs(rr, null, true);
+  if (rrArray.indexOf('TXT') >= 0) {
+    ret.txt = ret.txt || [];
+    ret.txt.push(parseTXT(normalizeRR(rr, 'TXT'), ret.txt));
+  } else if (rrArray.indexOf('$ORIGIN') === 0) {
+    ret.$origin = rrArray[1];
+  } else if (rrArray.indexOf('$TTL') === 0) {
+    ret.$ttl = rrArray[1];
+  } else if (rrArray.indexOf('SOA') >= 0) {
+    ret.soa = parseSOA(rrArray);
+  } else if (rrArray.indexOf('NS') >= 0) {
+    ret.ns = ret.ns || [];
+    ret.ns.push(parseNS(normalizeRR(rr, 'NS'), ret.ns));
+  } else if (rrArray.indexOf('A') >= 0) {
+    ret.a = ret.a || [];
+    ret.a.push(parseA(normalizeRR(rr, 'A'), ret.a));
+  } else if (rrArray.indexOf('AAAA') >= 0) {
+    ret.aaaa = ret.aaaa || [];
+    ret.aaaa.push(parseAAAA(normalizeRR(rr, 'AAAA'), ret.aaaa));
+  } else if (rrArray.indexOf('CNAME') >= 0) {
+    ret.cname = ret.cname || [];
+    ret.cname.push(parseCNAME(normalizeRR(rr, 'CNAME'), ret.cname));
+  } else if (rrArray.indexOf('MX') >= 0) {
+    ret.mx = ret.mx || [];
+    ret.mx.push(parseMX(normalizeRR(rr, 'MX'), ret.mx));
+  } else if (rrArray.indexOf('PTR') >= 0) {
+    ret.ptr = ret.ptr || [];
+    ret.ptr.push(parsePTR(normalizeRR(rr, 'PTR'), ret.ptr, ret.$origin));
+  } else if (rrArray.indexOf('SRV') >= 0) {
+    ret.srv = ret.srv || [];
+    ret.srv.push(parseSRV(normalizeRR(rr, 'SRV'), ret.srv));
+  } else if (rrArray.indexOf('SPF') >= 0) {
+    ret.spf = ret.spf || [];
+    ret.spf.push(parseSPF(normalizeRR(rr, 'SPF'), ret.spf));
+  } else if (rrArray.indexOf('CAA') >= 0) {
+    ret.caa = ret.caa || [];
+    ret.caa.push(parseCAA(normalizeRR(rr, 'CAA'), ret.caa));
+  }
+}
+
 let parseRRs = function (text) {
   let ret = {};
   let rrs = text.split('\n');
@@ -279,44 +358,20 @@ let parseRRs = function (text) {
     if (!rr.trim()) {
       continue;
     }
-    let rrArray = splitArgs(rr, null, true);
-    if (rrArray.indexOf('TXT') >= 0) {
-      ret.txt = ret.txt || [];
-      ret.txt.push(parseTXT(normalizeRR(rr, 'TXT'), ret.txt));
-    } else if (rrArray.indexOf('$ORIGIN') === 0) {
-      ret.$origin = rrArray[1];
-    } else if (rrArray.indexOf('$TTL') === 0) {
-      ret.$ttl = rrArray[1];
-    } else if (rrArray.indexOf('SOA') >= 0) {
-      ret.soa = parseSOA(rrArray);
-    } else if (rrArray.indexOf('NS') >= 0) {
-      ret.ns = ret.ns || [];
-      ret.ns.push(parseNS(normalizeRR(rr, 'NS'), ret.ns));
-    } else if (rrArray.indexOf('A') >= 0) {
-      ret.a = ret.a || [];
-      ret.a.push(parseA(normalizeRR(rr, 'A'), ret.a));
-    } else if (rrArray.indexOf('AAAA') >= 0) {
-      ret.aaaa = ret.aaaa || [];
-      ret.aaaa.push(parseAAAA(normalizeRR(rr, 'AAAA'), ret.aaaa));
-    } else if (rrArray.indexOf('CNAME') >= 0) {
-      ret.cname = ret.cname || [];
-      ret.cname.push(parseCNAME(normalizeRR(rr, 'CNAME'), ret.cname));
-    } else if (rrArray.indexOf('MX') >= 0) {
-      ret.mx = ret.mx || [];
-      ret.mx.push(parseMX(normalizeRR(rr, 'MX'), ret.mx));
-    } else if (rrArray.indexOf('PTR') >= 0) {
-      ret.ptr = ret.ptr || [];
-      ret.ptr.push(parsePTR(normalizeRR(rr, 'PTR'), ret.ptr, ret.$origin));
-    } else if (rrArray.indexOf('SRV') >= 0) {
-      ret.srv = ret.srv || [];
-      ret.srv.push(parseSRV(normalizeRR(rr, 'SRV'), ret.srv));
-    } else if (rrArray.indexOf('SPF') >= 0) {
-      ret.spf = ret.spf || [];
-      ret.spf.push(parseSPF(normalizeRR(rr, 'SPF'), ret.spf));
-    } else if (rrArray.indexOf('CAA') >= 0) {
-      ret.caa = ret.caa || [];
-      ret.caa.push(parseCAA(normalizeRR(rr, 'CAA'), ret.caa));
+    parseRR(rr, ret);
+  }
+  return ret;
+};
+
+let parseRRsAsync = async function (text) {
+  let ret = {};
+  let rrs = text.split('\n');
+  for (let rr of rrs) {
+    if (!rr.trim()) {
+      continue;
     }
+    parseRR(rr, ret);
+    await interrupt();
   }
   return ret;
 };

--- a/lib/zonefile.js
+++ b/lib/zonefile.js
@@ -46,6 +46,8 @@ let defaultTemplate = `; Zone: {zone}
 
 `;
 
+let interrupt = () => new Promise(resolve => setTimeout(resolve, 0));
+
 let generate = function (options, template) {
   template = template || defaultTemplate;
   template = process$ORIGIN(options['$origin'], template);
@@ -208,33 +210,68 @@ let parse = function (text) {
   return parseRRs(text);
 };
 
+let parseAsync = async function (text) {
+  text = removeComments(text);
+  await interrupt();
+  text = await flattenAsync(text);
+  await interrupt();
+  return parseRRsAsync(text);
+};
+
+// Keep this regex definition out of the function as it's expensive
+let removeCommentsRegex = /\\"|"(?:\\"|[^"])*"|((^|[^\\])\;.*)/g;
+
 let removeComments = function (text) {
   // let re = /(^|[^\\])\;(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$).*/g;
   // return text.replace(re, function (m, g1) {
   //     return g1 ? g1 : ""; // if g1 is set/matched, re-insert it, else remove
   // });
 
-  let re = /\\"|"(?:\\"|[^"])*"|((^|[^\\])\;.*)/g;
-  return text.replace(re, function (m, g1) {
+  return text.replace(removeCommentsRegex, function (m, g1) {
     return !g1 ? m : ""; // if g1 is not set/matched, re-insert it, else remove
   });
 };
 
+let flattenRegex = /\([\s\S]*?\)/gim;
+
+let replaceWhitespaces = function (text) {
+  return text.replace(/\s+/gm, ' ');
+}
+
 let flatten = function (text) {
   let captured = [];
-  let re = /\([\s\S]*?\)/gim;
-  let match = re.exec(text);
+  let match = flattenRegex.exec(text);
   while (match !== null) {
-    match.replacement = match[0].replace(/\s+/gm, ' ');
+    match.replacement = replaceWhitespaces(text);
     captured.push(match);
     // captured Text, index, input
-    match = re.exec(text);
+    match = flattenRegex.exec(text);
   }
   let arrText = text.split('');
   for (match of captured) {
     arrText.splice(match.index, match[0].length, match.replacement);
   }
   return arrText.join('').replace(/\(|\)/gim, ' ');
+};
+
+// this function should match flatten above, the only difference is the added interrupt.
+let flattenAsync = async function (text) {
+  let captured = [];
+  let match = flattenRegex.exec(text);
+  while (match !== null) {
+    match.replacement = replaceWhitespaces(text);
+    captured.push(match);
+    // captured Text, index, input
+    match = flattenRegex.exec(text);
+    await interrupt();
+  }
+  let arrText = text.split('');
+  for (match of captured) {
+    arrText.splice(match.index, match[0].length, match.replacement);
+  }
+  let joinedText = arrText.join('');
+  await interrupt();
+  return joinedText.replace(/\(|\)/gim, ' ');
 };
 
 let normalizeRR = function (rr, rrType) {
@@ -272,6 +309,47 @@ let normalizeRR = function (rr, rrType) {
   };
 };
 
+let parseRR = function (rr, ret) {
+  let rrArray = splitArgs(rr, null, true);
+  if (rrArray.indexOf('TXT') >= 0) {
+    ret.txt = ret.txt || [];
+    ret.txt.push(parseTXT(normalizeRR(rr, 'TXT'), ret.txt));
+  } else if (rrArray.indexOf('$ORIGIN') === 0) {
+    ret.$origin = rrArray[1];
+  } else if (rrArray.indexOf('$TTL') === 0) {
+    ret.$ttl = rrArray[1];
+  } else if (rrArray.indexOf('SOA') >= 0) {
+    ret.soa = parseSOA(rrArray);
+  } else if (rrArray.indexOf('NS') >= 0) {
+    ret.ns = ret.ns || [];
+    ret.ns.push(parseNS(normalizeRR(rr, 'NS'), ret.ns));
+  } else if (rrArray.indexOf('A') >= 0) {
+    ret.a = ret.a || [];
+    ret.a.push(parseA(normalizeRR(rr, 'A'), ret.a));
+  } else if (rrArray.indexOf('AAAA') >= 0) {
+    ret.aaaa = ret.aaaa || [];
+    ret.aaaa.push(parseAAAA(normalizeRR(rr, 'AAAA'), ret.aaaa));
+  } else if (rrArray.indexOf('CNAME') >= 0) {
+    ret.cname = ret.cname || [];
+    ret.cname.push(parseCNAME(normalizeRR(rr, 'CNAME'), ret.cname));
+  } else if (rrArray.indexOf('MX') >= 0) {
+    ret.mx = ret.mx || [];
+    ret.mx.push(parseMX(normalizeRR(rr, 'MX'), ret.mx));
+  } else if (rrArray.indexOf('PTR') >= 0) {
+    ret.ptr = ret.ptr || [];
+    ret.ptr.push(parsePTR(normalizeRR(rr, 'PTR'), ret.ptr, ret.$origin));
+  } else if (rrArray.indexOf('SRV') >= 0) {
+    ret.srv = ret.srv || [];
+    ret.srv.push(parseSRV(normalizeRR(rr, 'SRV'), ret.srv));
+  } else if (rrArray.indexOf('SPF') >= 0) {
+    ret.spf = ret.spf || [];
+    ret.spf.push(parseSPF(normalizeRR(rr, 'SPF'), ret.spf));
+  } else if (rrArray.indexOf('CAA') >= 0) {
+    ret.caa = ret.caa || [];
+    ret.caa.push(parseCAA(normalizeRR(rr, 'CAA'), ret.caa));
+  }
+}
+
 let parseRRs = function (text) {
   let ret = {};
   let rrs = text.split('\n');
@@ -279,44 +357,20 @@ let parseRRs = function (text) {
     if (!rr.trim()) {
       continue;
     }
-    let rrArray = splitArgs(rr, null, true);
-    if (rrArray.indexOf('TXT') >= 0) {
-      ret.txt = ret.txt || [];
-      ret.txt.push(parseTXT(normalizeRR(rr, 'TXT'), ret.txt));
-    } else if (rrArray.indexOf('$ORIGIN') === 0) {
-      ret.$origin = rrArray[1];
-    } else if (rrArray.indexOf('$TTL') === 0) {
-      ret.$ttl = rrArray[1];
-    } else if (rrArray.indexOf('SOA') >= 0) {
-      ret.soa = parseSOA(rrArray);
-    } else if (rrArray.indexOf('NS') >= 0) {
-      ret.ns = ret.ns || [];
-      ret.ns.push(parseNS(normalizeRR(rr, 'NS'), ret.ns));
-    } else if (rrArray.indexOf('A') >= 0) {
-      ret.a = ret.a || [];
-      ret.a.push(parseA(normalizeRR(rr, 'A'), ret.a));
-    } else if (rrArray.indexOf('AAAA') >= 0) {
-      ret.aaaa = ret.aaaa || [];
-      ret.aaaa.push(parseAAAA(normalizeRR(rr, 'AAAA'), ret.aaaa));
-    } else if (rrArray.indexOf('CNAME') >= 0) {
-      ret.cname = ret.cname || [];
-      ret.cname.push(parseCNAME(normalizeRR(rr, 'CNAME'), ret.cname));
-    } else if (rrArray.indexOf('MX') >= 0) {
-      ret.mx = ret.mx || [];
-      ret.mx.push(parseMX(normalizeRR(rr, 'MX'), ret.mx));
-    } else if (rrArray.indexOf('PTR') >= 0) {
-      ret.ptr = ret.ptr || [];
-      ret.ptr.push(parsePTR(normalizeRR(rr, 'PTR'), ret.ptr, ret.$origin));
-    } else if (rrArray.indexOf('SRV') >= 0) {
-      ret.srv = ret.srv || [];
-      ret.srv.push(parseSRV(normalizeRR(rr, 'SRV'), ret.srv));
-    } else if (rrArray.indexOf('SPF') >= 0) {
-      ret.spf = ret.spf || [];
-      ret.spf.push(parseSPF(normalizeRR(rr, 'SPF'), ret.spf));
-    } else if (rrArray.indexOf('CAA') >= 0) {
-      ret.caa = ret.caa || [];
-      ret.caa.push(parseCAA(normalizeRR(rr, 'CAA'), ret.caa));
+    parseRR(rr, ret);
+  }
+  return ret;
+};
+
+let parseRRsAsync = async function (text) {
+  let ret = {};
+  let rrs = text.split('\n');
+  for (let rr of rrs) {
+    if (!rr.trim()) {
+      continue;
     }
+    parseRR(rr, ret);
+    await interrupt();
   }
   return ret;
 };
@@ -590,7 +644,9 @@ let splitArgs = function (input, sep, keepQuotes) {
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   exports.generate = generate;
   exports.parse = parse;
+  exports.parseAsync = parseAsync;
 } else {
   window.zonefile_generate = generate;
   window.zonefile_parse = parse;
+  window.zonefile_parse_async = parseAsync;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,10 @@
-(function () {
+(async function () {
     let fs = require('fs');
     let zonefile = require('../lib/zonefile.js');
 
     console.log('##########', 'Generating forward zone file from JSON', '##########');
     let options = require('./zonefile_forward.json');
+    let asyncOutput = null;
     let output = zonefile.generate(options);
     console.log(output);
 
@@ -20,17 +21,29 @@
     console.log('##########', 'Parsing forward zone file to JSON', '##########');
     let text = fs.readFileSync('./zonefile_forward.txt', 'utf8');
     output = zonefile.parse(text);
+    asyncOutput = await zonefile.parseAsync(text);
+    if(JSON.stringify(output) !== JSON.stringify(asyncOutput)) {
+        throw new Error('sync and async parse output should be the same');
+    }
     console.log(output);
 
     console.log('\n');
     console.log('##########', 'Parsing reverse zone file to JSON', '##########');
     text = fs.readFileSync('./zonefile_reverse.txt', 'utf8');
     output = zonefile.parse(text);
+    asyncOutput = await zonefile.parseAsync(text);
+    if(JSON.stringify(output) !== JSON.stringify(asyncOutput)) {
+        throw new Error('sync and async parse output should be the same');
+    }
     console.log(output);
 
     console.log('\n');
     console.log('##########', 'Parsing reverse zone file (IPv6) to JSON', '##########');
     text = fs.readFileSync('./zonefile_reverse_ipv6.txt', 'utf8');
     output = zonefile.parse(text);
+    asyncOutput = await zonefile.parseAsync(text);
+    if(JSON.stringify(output) !== JSON.stringify(asyncOutput)) {
+        throw new Error('sync and async parse output should be the same');
+    }
     console.log(output);
 })();


### PR DESCRIPTION
This PR adds an additional export to the library called `parseAsync()`. This function behaves exactly like `parse()`, the only difference is that it contains interrupts so that it does not block the event loop for the whole operation. 